### PR TITLE
fix: model_summary_table() \w prior_none()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: BayesTools
 Title: Tools for Bayesian Analyses
-Version: 0.2.14
+Version: 0.2.15
 Description: Provides tools for conducting Bayesian analyses and Bayesian model averaging 
     (Kass and Raftery, 1995, <doi:10.1080/01621459.1995.10476572>, 
     Hoeting et al., 1999, <doi:10.1214/ss/1009212519>). The package contains 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## version 0.2.15
+### Fixes
+- fixing repeated print of previous prior distribution in `model_summary_table()` in case of `prior_none()`
+
 ## version 0.2.14
 ### Features
 - adding `contrast = "meandif"` to the `prior_factor` function which generates identical prior distributions for difference between the grand mean and each factor level

--- a/R/summary-tables.R
+++ b/R/summary-tables.R
@@ -657,7 +657,9 @@ model_summary_table <- function(model, model_description = NULL, title = NULL, f
   summary_priors  <- "Parameter prior distributions"
   for(i in seq_along(prior_list)){
     # get the prior name
-    if(remove_spike_0 && is.prior.point(prior_list[[i]]) && prior_list[[i]][["parameters"]][["location"]] == 0 || (names(prior_list)[[i]] %in% remove_parameters)){
+    if(is.prior.none(prior_list[[i]])){
+      next
+    }else if(remove_spike_0 && is.prior.point(prior_list[[i]]) && prior_list[[i]][["parameters"]][["location"]] == 0 || (names(prior_list)[[i]] %in% remove_parameters)){
       next
     }else if(is.prior.weightfunction(prior_list[[i]]) | is.prior.PET(prior_list[[i]]) | is.prior.PEESE(prior_list[[i]])){
       temp_prior <- print(prior_list[[i]], silent = TRUE, short_name = short_name)


### PR DESCRIPTION
### Fixes
- fixing repeated print of previous prior distribution in `model_summary_table()` in case of `prior_none()`